### PR TITLE
Modify the source generator to create `AvaloniaXamlLoader` classes

### DIFF
--- a/samples/Avalonia.Themes.Fluent/FluentTheme.xaml.cs
+++ b/samples/Avalonia.Themes.Fluent/FluentTheme.xaml.cs
@@ -30,7 +30,7 @@ namespace Avalonia.Themes.Fluent
         /// <param name="sp">The parent's service provider.</param>
         public FluentTheme(IServiceProvider? sp = null)
         {
-            InitializeComponent();
+            AvaloniaXamlLoader.Load(this);
             
             _compactStyles = ResolveCompactStyles(GetAndRemove("CompactStyles"));
 

--- a/samples/SourceGenCrudSample/App.axaml.cs
+++ b/samples/SourceGenCrudSample/App.axaml.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using SourceGenCrudSample.ViewModels;
+using Avalonia.Markup.Xaml;
 
 namespace SourceGenCrudSample;
 
@@ -8,7 +9,7 @@ public partial class App : Application
 {
     public override void Initialize()
     {
-        InitializeComponent();
+        AvaloniaXamlLoader.Load(this);
     }
 
     public override void OnFrameworkInitializationCompleted()

--- a/samples/SourceGenCrudSample/MainWindow.axaml.cs
+++ b/samples/SourceGenCrudSample/MainWindow.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
 
 namespace SourceGenCrudSample;
 
@@ -6,6 +7,6 @@ public partial class MainWindow : Window
 {
     public MainWindow()
     {
-        InitializeComponent();
+        AvaloniaXamlLoader.Load(this);
     }
 }

--- a/src/XamlToCSharpGenerator.Avalonia/Emission/AvaloniaCodeEmitter.cs
+++ b/src/XamlToCSharpGenerator.Avalonia/Emission/AvaloniaCodeEmitter.cs
@@ -426,70 +426,13 @@ public sealed class AvaloniaCodeEmitter : IXamlCodeEmitter
 
         if (viewModel.Document.IsClassBacked)
         {
-            sourceBuilder.AppendLine("        public void InitializeComponent(bool loadXaml = true)");
+            sourceBuilder.AppendLine($"        private static class AvaloniaXamlLoader");
+            sourceBuilder.AppendLine("        {");
+            sourceBuilder.AppendLine($"            public static void Load({className} __obj, bool loadXaml = true)");
             sourceBuilder.AppendLine("            {");
-            sourceBuilder.AppendLine("                var __loadedWithSourceGen = false;");
-            sourceBuilder.AppendLine("                if (loadXaml)");
-            sourceBuilder.AppendLine("                {");
-            sourceBuilder.AppendLine("                    __PopulateGeneratedObjectGraph(this, null);");
-            sourceBuilder.AppendLine("                    __loadedWithSourceGen = true;");
-            sourceBuilder.AppendLine("                }");
-            sourceBuilder.AppendLine();
-            sourceBuilder.AppendLine("                if (!__loadedWithSourceGen)");
-            sourceBuilder.AppendLine("                {");
-            foreach (var namedElement in viewModel.NamedElements)
-            {
-                sourceBuilder.AppendLine(
-                    $"                    {SanitizeIdentifier(namedElement.Name)} = this.FindNameScope()?.Find<{namedElement.TypeName}>(\"{Escape(namedElement.Name)}\")!;");
-            }
-            sourceBuilder.AppendLine("                }");
-            sourceBuilder.AppendLine();
-            if (viewModel.EnableHotReload || viewModel.EnableHotDesign)
-            {
-                var escapedSourcePath = Escape(viewModel.Document.FilePath);
-                sourceBuilder.AppendLine("                if (__loadedWithSourceGen)");
-                sourceBuilder.AppendLine("                {");
-                sourceBuilder.AppendLine("                    __TrackAndReconcileSourceGenHotReloadState(this);");
-
-                if (viewModel.EnableHotReload)
-                {
-                    sourceBuilder.AppendLine(
-                        $"                    global::XamlToCSharpGenerator.Runtime.XamlSourceGenHotReloadManager.Register(this, static __instance => (({viewModel.RootObject.TypeName})__instance).__ApplySourceGenHotReload(), new global::XamlToCSharpGenerator.Runtime.SourceGenHotReloadRegistrationOptions");
-                    sourceBuilder.AppendLine("                    {");
-                    sourceBuilder.AppendLine($"                        BuildUri = \"{escapedUri}\",");
-                    sourceBuilder.AppendLine($"                        SourcePath = \"{escapedSourcePath}\",");
-                    sourceBuilder.AppendLine("                        CaptureState = static __instance =>");
-                    sourceBuilder.AppendLine("                            __instance is global::Avalonia.StyledElement __styledElement");
-                    sourceBuilder.AppendLine("                                ? __styledElement.DataContext");
-                    sourceBuilder.AppendLine("                                : null,");
-                    sourceBuilder.AppendLine("                        RestoreState = static (__instance, __state) =>");
-                    sourceBuilder.AppendLine("                        {");
-                    sourceBuilder.AppendLine("                            if (__instance is global::Avalonia.StyledElement __styledElement &&");
-                    sourceBuilder.AppendLine("                                __styledElement.DataContext is null)");
-                    sourceBuilder.AppendLine("                            {");
-                    sourceBuilder.AppendLine("                                __styledElement.DataContext = __state;");
-                    sourceBuilder.AppendLine("                            }");
-                    sourceBuilder.AppendLine("                        }");
-                    sourceBuilder.AppendLine("                    });");
-                }
-
-                if (viewModel.EnableHotDesign)
-                {
-                    sourceBuilder.AppendLine(
-                        $"                    global::XamlToCSharpGenerator.Runtime.XamlSourceGenHotDesignManager.Register(this, static __instance => (({viewModel.RootObject.TypeName})__instance).__ApplySourceGenHotReload(), new global::XamlToCSharpGenerator.Runtime.SourceGenHotDesignRegistrationOptions");
-                    sourceBuilder.AppendLine("                    {");
-                    sourceBuilder.AppendLine($"                        BuildUri = \"{escapedUri}\",");
-                    sourceBuilder.AppendLine($"                        SourcePath = \"{escapedSourcePath}\",");
-                    sourceBuilder.AppendLine($"                        DocumentRole = {hotDesignDocumentRoleExpression},");
-                    sourceBuilder.AppendLine($"                        ArtifactKind = {hotDesignArtifactKindExpression},");
-                    sourceBuilder.AppendLine($"                        ScopeHints = {hotDesignScopeHintsExpression}");
-                    sourceBuilder.AppendLine("                    });");
-                }
-
-                sourceBuilder.AppendLine("                }");
-            }
-
+            EmitInitializationBody(sourceBuilder, viewModel, "__obj", escapedUri, hotDesignDocumentRoleExpression, hotDesignArtifactKindExpression, hotDesignScopeHintsExpression);
             sourceBuilder.AppendLine("            }");
+            sourceBuilder.AppendLine("        }");
         }
         sourceBuilder.AppendLine("    }");
         sourceBuilder.AppendLine("}");
@@ -498,6 +441,80 @@ public sealed class AvaloniaCodeEmitter : IXamlCodeEmitter
         var source = sourceBuilder.ToString();
         source = RewriteCompiledBindingExpressionInvocations(source, compiledBindingAccessorEmissionPlan);
         return (hintName, source);
+    }
+
+    private static void EmitInitializationBody(
+        StringBuilder sourceBuilder,
+        ResolvedViewModel viewModel,
+        string selfExpression,
+        string escapedUri,
+        string hotDesignDocumentRoleExpression,
+        string hotDesignArtifactKindExpression,
+        string hotDesignScopeHintsExpression)
+    {
+        sourceBuilder.AppendLine("                var __loadedWithSourceGen = false;");
+        sourceBuilder.AppendLine("                if (loadXaml)");
+        sourceBuilder.AppendLine("                {");
+        sourceBuilder.AppendLine($"                    __PopulateGeneratedObjectGraph({selfExpression}, null);");
+        sourceBuilder.AppendLine("                    __loadedWithSourceGen = true;");
+        sourceBuilder.AppendLine("                }");
+        sourceBuilder.AppendLine();
+        sourceBuilder.AppendLine("                if (!__loadedWithSourceGen)");
+        sourceBuilder.AppendLine("                {");
+        foreach (var namedElement in viewModel.NamedElements)
+        {
+            var fieldRef = selfExpression == "this"
+                ? SanitizeIdentifier(namedElement.Name)
+                : $"{selfExpression}.{SanitizeIdentifier(namedElement.Name)}";
+            sourceBuilder.AppendLine(
+                $"                    {fieldRef} = {selfExpression}.FindNameScope()?.Find<{namedElement.TypeName}>(\"{Escape(namedElement.Name)}\")!;");
+        }
+        sourceBuilder.AppendLine("                }");
+        sourceBuilder.AppendLine();
+        if (viewModel.EnableHotReload || viewModel.EnableHotDesign)
+        {
+            var escapedSourcePath = Escape(viewModel.Document.FilePath);
+            sourceBuilder.AppendLine("                if (__loadedWithSourceGen)");
+            sourceBuilder.AppendLine("                {");
+            sourceBuilder.AppendLine($"                    __TrackAndReconcileSourceGenHotReloadState({selfExpression});");
+
+            if (viewModel.EnableHotReload)
+            {
+                sourceBuilder.AppendLine(
+                    $"                    global::XamlToCSharpGenerator.Runtime.XamlSourceGenHotReloadManager.Register({selfExpression}, static __instance => (({viewModel.RootObject.TypeName})__instance).__ApplySourceGenHotReload(), new global::XamlToCSharpGenerator.Runtime.SourceGenHotReloadRegistrationOptions");
+                sourceBuilder.AppendLine("                    {");
+                sourceBuilder.AppendLine($"                        BuildUri = \"{escapedUri}\",");
+                sourceBuilder.AppendLine($"                        SourcePath = \"{escapedSourcePath}\",");
+                sourceBuilder.AppendLine("                        CaptureState = static __instance =>");
+                sourceBuilder.AppendLine("                            __instance is global::Avalonia.StyledElement __styledElement");
+                sourceBuilder.AppendLine("                                ? __styledElement.DataContext");
+                sourceBuilder.AppendLine("                                : null,");
+                sourceBuilder.AppendLine("                        RestoreState = static (__instance, __state) =>");
+                sourceBuilder.AppendLine("                        {");
+                sourceBuilder.AppendLine("                            if (__instance is global::Avalonia.StyledElement __styledElement &&");
+                sourceBuilder.AppendLine("                                __styledElement.DataContext is null)");
+                sourceBuilder.AppendLine("                            {");
+                sourceBuilder.AppendLine("                                __styledElement.DataContext = __state;");
+                sourceBuilder.AppendLine("                            }");
+                sourceBuilder.AppendLine("                        }");
+                sourceBuilder.AppendLine("                    });");
+            }
+
+            if (viewModel.EnableHotDesign)
+            {
+                sourceBuilder.AppendLine(
+                    $"                    global::XamlToCSharpGenerator.Runtime.XamlSourceGenHotDesignManager.Register({selfExpression}, static __instance => (({viewModel.RootObject.TypeName})__instance).__ApplySourceGenHotReload(), new global::XamlToCSharpGenerator.Runtime.SourceGenHotDesignRegistrationOptions");
+                sourceBuilder.AppendLine("                    {");
+                sourceBuilder.AppendLine($"                        BuildUri = \"{escapedUri}\",");
+                sourceBuilder.AppendLine($"                        SourcePath = \"{escapedSourcePath}\",");
+                sourceBuilder.AppendLine($"                        DocumentRole = {hotDesignDocumentRoleExpression},");
+                sourceBuilder.AppendLine($"                        ArtifactKind = {hotDesignArtifactKindExpression},");
+                sourceBuilder.AppendLine($"                        ScopeHints = {hotDesignScopeHintsExpression}");
+                sourceBuilder.AppendLine("                    });");
+            }
+
+            sourceBuilder.AppendLine("                }");
+        }
     }
 
     private static int EstimateSourceCapacity(ResolvedViewModel viewModel)


### PR DESCRIPTION
This pull request wasn't meant to be merged, but just a way of showing the possibility to minimize the migration efforts of end users.

If a similar mechanism is implemented, modification can be limited to `Program.cs` and the project file only.

Related to #28 