### PR TITLE
Send source assembly path in UpdateXaml message

### DIFF
--- a/src/XamlToCSharpGenerator.PreviewerHost/PreviewSession.cs
+++ b/src/XamlToCSharpGenerator.PreviewerHost/PreviewSession.cs
@@ -966,7 +966,7 @@ internal sealed class PreviewSession : IPreviewHostSession
 
         await transport.SendUpdateXamlAsync(
             xamlText,
-            assemblyPath: null,
+            assemblyPath: _sourceAssemblyPath,
             xamlFileProjectPath,
             cancellationToken).ConfigureAwait(false);
     }


### PR DESCRIPTION
Allows Avalonia XamlX previewer to read the `.deps.json` file and load correct assemblies.

Resolves #43 